### PR TITLE
Minor fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,10 +32,10 @@
     "url": "https://github.com/davidnmora/use-d3-transition/issues"
   },
   "homepage": "https://github.com/davidnmora/use-d3-transition#readme",
-  "dependencies": {
-    "d3-selection": "1.4.1",
-    "d3-transition": "1.3.2",
-    "react": "^16.8.0"
+  "peerDependencies": {
+    "d3-selection": "^1.4.1",
+    "d3-transition": "^1.3.2",
+    "react": "^16.13.0"
   },
   "devDependencies": {
     "prettier": "2.0.4"

--- a/src/useD3Transition.js
+++ b/src/useD3Transition.js
@@ -7,7 +7,6 @@ const DEFAULT_TRANSITION_DURATION = 800
 const useD3Transition = ({
   attrsToTransitionTo,
   deps,
-
   attrsToTransitionFromInitially = null,
   duration = null,
   easingFunction = null,

--- a/src/useD3Transition.js
+++ b/src/useD3Transition.js
@@ -39,7 +39,7 @@ const useD3Transition = ({
 
     transition.on('end', () => {
       if (!ref.current) return
-      setAttrState(attrNames)
+      setAttrState(attrsToTransitionTo)
     })
     return () => element.interrupt() // cleanup by ending transitions
   }


### PR DESCRIPTION
Makes d3 and react peer dependencies. Otherwise, I get 2 different versions of d3-selection in use which in my case is problematic.
Also, sets the correct attribute state at the end of the transition